### PR TITLE
URL Cleanup

### DIFF
--- a/spring-batch-admin-angularjs/build.gradle
+++ b/spring-batch-admin-angularjs/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     repositories {
         maven {
             mavenCentral()
-            url 'http://repo.springsource.org/libs-milestone/'
+            url 'https://repo.springsource.org/libs-milestone/'
         }
     }
     dependencies {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://repo.springsource.org/libs-milestone/ migrated to:  
  https://repo.springsource.org/libs-milestone/ ([https](https://repo.springsource.org/libs-milestone/) result 301).